### PR TITLE
feat: Monitor/Logger support

### DIFF
--- a/Sources/GoodPersistence/Configuration.swift
+++ b/Sources/GoodPersistence/Configuration.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  
+//
+//  Created by Dominik Pethö on 05/04/2024.
+//
+
+import Foundation
+
+public final class GoodPersistence {
+
+    /// Used for configuring the GoodPoersistance monitors
+    public final class Configuration {
+
+        public static private(set) var monitors: [PersistenceMonitor] = []
+
+        /// Pass monitors to parameters. Each monitor invokes it's appropriate function.
+        public static func configure(monitors: [PersistenceMonitor]) {
+            Self.monitors = monitors
+        }
+
+    }
+
+}

--- a/Sources/GoodPersistence/Configuration.swift
+++ b/Sources/GoodPersistence/Configuration.swift
@@ -1,11 +1,9 @@
 //
-//  File.swift
-//  
+//  Configuration.swift
+//
 //
 //  Created by Dominik Pethö on 05/04/2024.
 //
-
-import Foundation
 
 public final class GoodPersistence {
 

--- a/Sources/GoodPersistence/PersistenceLogger.swift
+++ b/Sources/GoodPersistence/PersistenceLogger.swift
@@ -1,0 +1,25 @@
+//
+//  File.swift
+//  
+//
+//  Created by Dominik Pethö on 05/04/2024.
+//
+
+import Foundation
+
+final class PersistenceLogger {
+
+    static func log(error: Error) {
+        GoodPersistence.Configuration.monitors.forEach {
+            $0.didReceive($0, error: error)
+        }
+    }
+
+    static func log(message: String) {
+        GoodPersistence.Configuration.monitors.forEach {
+            $0.didReceive($0, message: message)
+        }
+    }
+
+}
+

--- a/Sources/GoodPersistence/PersistenceLogger.swift
+++ b/Sources/GoodPersistence/PersistenceLogger.swift
@@ -1,11 +1,9 @@
 //
-//  File.swift
+//  PersistenceLogger.swift
 //  
 //
 //  Created by Dominik Pethö on 05/04/2024.
 //
-
-import Foundation
 
 final class PersistenceLogger {
 

--- a/Sources/GoodPersistence/PersistenceMonitor.swift
+++ b/Sources/GoodPersistence/PersistenceMonitor.swift
@@ -1,0 +1,23 @@
+//
+//  File.swift
+//  
+//
+//  Created by Dominik Pethö on 05/04/2024.
+//
+
+import Foundation
+
+/// Extend function to receive error or message from GoodPersistance library
+public protocol PersistenceMonitor {
+
+    func didReceive(_ monitor: PersistenceMonitor, error: Error)
+    func didReceive(_ monitor: PersistenceMonitor, message: String)
+
+}
+
+/// Default implementation of optional protocol functions
+public extension PersistenceMonitor {
+
+    func didReceive(_ monitor: PersistenceMonitor, message: String) {}
+
+}

--- a/Sources/GoodPersistence/PersistenceMonitor.swift
+++ b/Sources/GoodPersistence/PersistenceMonitor.swift
@@ -1,11 +1,9 @@
 //
-//  File.swift
-//  
+//  PersistenceMonitor.swift
+//
 //
 //  Created by Dominik Pethö on 05/04/2024.
 //
-
-import Foundation
 
 /// Extend function to receive error or message from GoodPersistance library
 public protocol PersistenceMonitor {

--- a/Tests/GoodPersistenceTests/TestMonitor.swift
+++ b/Tests/GoodPersistenceTests/TestMonitor.swift
@@ -1,0 +1,26 @@
+//
+//  File.swift
+//  
+//
+//  Created by Dominik Pethö on 05/04/2024.
+//
+
+import Foundation
+import GoodPersistence
+
+final class TestMonitor: PersistenceMonitor {
+
+    var error: Error?
+    var message: String?
+
+    func didReceive(_ monitor: PersistenceMonitor, error: Error) {
+        debugPrint(error)
+        self.error = error
+    }
+
+    func didReceive(_ monitor: PersistenceMonitor, message: String) {
+        debugPrint(message)
+        self.message = message
+    }
+
+}

--- a/Tests/GoodPersistenceTests/TestMonitor.swift
+++ b/Tests/GoodPersistenceTests/TestMonitor.swift
@@ -4,8 +4,6 @@
 //
 //  Created by Dominik Pethö on 05/04/2024.
 //
-
-import Foundation
 import GoodPersistence
 
 final class TestMonitor: PersistenceMonitor {

--- a/Tests/GoodPersistenceTests/UserDefaultTest.swift
+++ b/Tests/GoodPersistenceTests/UserDefaultTest.swift
@@ -5,6 +5,7 @@ final class UserDefaultsTests: XCTestCase {
 
     enum C {
 
+        static let userDefaultsObjectTestMonitorKey = "Test Monitor"
         static let firstCondition = [1]
         static let secondCondition = [1,2]
         static let userDefaultsObjectKey = "numbers3"
@@ -26,9 +27,107 @@ final class UserDefaultsTests: XCTestCase {
 
     }
 
-    override class func tearDown() {
+    func testUserDefaultsStoresStructureIsNotRetrievedBecauseIsEmpty() {
+        struct EmptyTest: Codable {
+            let value: String
+        }
+
+        let monitor = TestMonitor()
+        GoodPersistence.Configuration.configure(monitors: [monitor])
+
+        @UserDefaultValue(C.userDefaultsObjectTestMonitorKey, defaultValue: .init(value: ""))
+        var test: EmptyTest
+
+        let _ = test
+
+        XCTAssert(
+            monitor.message == "Default UserDefaults value [EmptyTest(value: \"\")] for key [Test Monitor] used. Reason: Data not retrieved.",
+            "Monitor should contain message for using default value. Contains: \(monitor.message)."
+        )
+    }
+
+    func testUserDefaultsStoresStructureDataHasChanged() {
+        struct EmptyTest: Codable {
+            let value: String
+        }
+
+        let monitor = TestMonitor()
+        GoodPersistence.Configuration.configure(monitors: [monitor])
+
+        @UserDefaultValue(C.userDefaultsObjectTestMonitorKey, defaultValue: .init(value: ""))
+        var test: EmptyTest
+
+        test = .init(value: "newValue")
+
+        XCTAssert(
+            monitor.message == "UserDefaults data for key [Test Monitor] has changed to EmptyTest(value: \"newValue\").",
+            "Monitor should contain message for using default value. Contains: \(monitor.message)."
+        )
+    }
+
+    func testMessageForUserDefaultsStoresStructureIsNotDecodedCorrectly() {
+        struct EmptyTest: Codable {
+            let value: String
+        }
+
+        struct EmptyTestFailure: Codable {
+            let value: String
+            let secondValue: String
+        }
+
+        let monitor = TestMonitor()
+        GoodPersistence.Configuration.configure(monitors: [monitor])
+
+        @UserDefaultValue(C.userDefaultsObjectTestMonitorKey, defaultValue: .init(value: ""))
+        var test: EmptyTest
+        test = .init(value: "value")
+
+        @UserDefaultValue(C.userDefaultsObjectTestMonitorKey, defaultValue: .init(value: "", secondValue: ""))
+        var testFailure: EmptyTestFailure
+        let _ = testFailure
+
+        XCTAssert(
+            monitor.message == "Default UserDefaults value [EmptyTestFailure(value: \"\", secondValue: \"\")] for key [Test Monitor] used. Reason: Decoding error.",
+            "Monitor should contain message for using default value. Contains: \(monitor.message)."
+        )
+
+        XCTAssert(
+            monitor.error != nil,
+            "Monitor should contain error for using default value. Contains error: \(monitor.error)."
+        )
+    }
+
+    func testErrorForDefaultsStoresStructureIsNotDecodedCorrectly() {
+        struct EmptyTest: Codable {
+            let value: String
+        }
+
+        struct EmptyTestFailure: Codable {
+            let value: String
+            let secondValue: String
+        }
+
+        let monitor = TestMonitor()
+        GoodPersistence.Configuration.configure(monitors: [monitor])
+
+        @UserDefaultValue(C.userDefaultsObjectTestMonitorKey, defaultValue: .init(value: ""))
+        var test: EmptyTest
+        test = .init(value: "value")
+
+        @UserDefaultValue(C.userDefaultsObjectTestMonitorKey, defaultValue: .init(value: "", secondValue: ""))
+        var testFailure: EmptyTestFailure
+        let _ = testFailure
+
+        XCTAssert(
+            monitor.error != nil,
+            "Monitor should contain error for using default value. Contains error: \(monitor.error)."
+        )
+    }
+
+    override func tearDown() {
         UserDefaults.standard.removeObject(forKey: C.userDefaultsObjectKey)
-        UserDefaults.standard.synchronize()
+        UserDefaults.standard.removeObject(forKey: C.userDefaultsObjectTestMonitorKey)
+        GoodPersistence.Configuration.configure(monitors: [])
     }
 
 }


### PR DESCRIPTION
Added simple option to log events in library. Main use-case to implement such a solution is support for simple logging to Crashlytics, which in current state is not possible.

Created general solution, which could be used for logging to Crashlytics or Sentry. It doesn't depend on specific library, thats why I used "Monitor" naming.

Moreover found an issue with newValuePublisher inside the keychain, which is automatically completed after receiving forst error. We should support continuos error logging for such a scenario. Suggesting using one of the following options:
1. private let newSubject: PassthroughSubject<Either<T, KeychainError>, Never> = PassthroughSubject()
2. private let newSubject: PassthroughSubject<Event<T, KeychainError>, Never> = PassthroughSubject()

Otherwise, it can't be easily used for logging, because I would have to catch each place where the newSubject property is used. Current proposed solution is more generic and can be placed only on one place to log events to Crashlytics or Sentry.